### PR TITLE
feat: 캘린더 페이지 디자인만 작업

### DIFF
--- a/src/common/components/Navigation/Navigation.tsx
+++ b/src/common/components/Navigation/Navigation.tsx
@@ -28,7 +28,7 @@ const StyledNavigation = styled.header`
   align-items: center;
   justify-content: space-between;
   background-color: ${theme.color.black};
-  ${theme.font['22-bold']};
+  ${theme.font.bold22};
 `;
 
 const StyledNavigationLeft = styled.div`

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/button-has-type */
 import { CalendarPageFooter } from '@common/components/Footer';
 import { CalendarPageNavigation } from '@common/components/Navigation';
+import { SvgIcon } from '@common/components/SvgIcon';
 import styled from '@emotion/styled';
 import { theme } from '@styles/theme';
 
@@ -9,22 +10,51 @@ const Home = () => {
     <>
       <CalendarPageNavigation />
       <div>캘린더 영역</div>
-      <div>
-        <StyledDate>07</StyledDate>
-        <StyledWord>DAY</StyledWord>
-        <StyledDate>12</StyledDate>
-        <StyledWord>RECORD</StyledWord>
-      </div>
+      <StyledContainer>
+        <div>
+          <StyledDate>07</StyledDate>
+          <StyledWord>DAY</StyledWord>
+          <StyledDate>12</StyledDate>
+          <StyledWord>RECORD</StyledWord>
+        </div>
+        <StyledRecordButton>
+          <SvgIcon id='chevronDown2' />
+        </StyledRecordButton>
+      </StyledContainer>
       <CalendarPageFooter />
     </>
   );
 };
 
+// NOTE: Footer 쪽 스타일과 상당히 유사해서 하나의 컴포넌트로 뺄 수 있을 것 같음
+const StyledContainer = styled.div`
+  position: absolute;
+  bottom: 0;
+  padding-bottom: 6.8rem;
+  padding-left: 2.4rem;
+  padding-right: 2.4rem;
+  width: calc(100% - 4.8rem);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
 const StyledDate = styled.span`
   ${theme.font.bold32}
 `;
 
 const StyledWord = styled.span`
-  ${theme.font.bold32}
+  ${theme.font.semibold16};
+  color: ${theme.color.gray07};
+`;
+
+const StyledRecordButton = styled.button`
+  all: unset;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${theme.color.white};
+  border-radius: 10rem;
+  width: 6.2rem;
+  height: 6.2rem;
 `;
 export default Home;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,30 @@
 /* eslint-disable react/button-has-type */
 import { CalendarPageFooter } from '@common/components/Footer';
 import { CalendarPageNavigation } from '@common/components/Navigation';
+import styled from '@emotion/styled';
+import { theme } from '@styles/theme';
 
 const Home = () => {
   return (
     <>
       <CalendarPageNavigation />
       <div>캘린더 영역</div>
+      <div>
+        <StyledDate>07</StyledDate>
+        <StyledWord>DAY</StyledWord>
+        <StyledDate>12</StyledDate>
+        <StyledWord>RECORD</StyledWord>
+      </div>
       <CalendarPageFooter />
     </>
   );
 };
 
+const StyledDate = styled.span`
+  ${theme.font.bold32}
+`;
+
+const StyledWord = styled.span`
+  ${theme.font.bold32}
+`;
 export default Home;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,10 +1,5 @@
 import { css } from '@emotion/react';
 
-/**
- * @description 디자인 시스템에 정의되어 있는 디자인 토큰
- * NOTE : 우선 gray 4개랑 기본 색깔만 정의함.
- */
-
 export const theme = {
   color: {
     black: '#000000',
@@ -28,97 +23,97 @@ export const theme = {
     gray12: '#1a1a1a',
   },
   font: {
-    '80-semibold': css`
+    semibold80: css`
       font-size: 8rem;
       font-weight: 600;
       line-height: 9.2rem;
     `,
-    '36-bold': css`
+    bold36: css`
       font-size: 3.6rem;
       font-weight: 700;
       line-height: 4.4rem;
     `,
-    '34-bold': css`
-      font-size: 3.6rem;
+    bold34: css`
+      font-size: 3.4rem;
       font-weight: 700;
       line-height: 4.4rem;
     `,
-    '32-bold': css`
-      font-size: 3.6rem;
+    bold32: css`
+      font-size: 3.2rem;
       font-weight: 700;
       line-height: 4.4rem;
     `,
-    '32-semibold': css`
+    semibold32: css`
       font-size: 3.2rem;
       font-weight: 600;
       line-height: 4.4rem;
     `,
-    '30-bold': css`
+    bold30: css`
       font-size: 3rem;
       font-weight: 700;
       line-height: 4.4rem;
     `,
-    '28-bold': css`
+    bold28: css`
       font-size: 2.8rem;
       font-weight: 700;
       line-height: 4.2rem;
     `,
-    '26-bold': css`
+    bold26: css`
       font-size: 2.6rem;
       font-weight: 700;
       line-height: 3.8rem;
     `,
-    '24-bold': css`
+    bold24: css`
       font-size: 2.4rem;
       font-weight: 700;
       line-height: 2.8rem;
     `,
-    '22-bold': css`
+    bold22: css`
       font-size: 2.2rem;
       font-weight: 700;
       line-height: 2.8rem;
     `,
-    '20-bold': css`
+    bold20: css`
       font-size: 2rem;
       font-weight: 700;
       line-height: 2.8rem;
     `,
-    '18-bold': css`
+    bold18: css`
       font-size: 1.8rem;
       font-weight: 700;
       line-height: 2.8rem;
     `,
-    '18-semibold': css`
+    semibold18: css`
       font-size: 1.8rem;
       font-weight: 700;
       line-height: 2.8rem;
     `,
-    '18-medium': css`
+    medium18: css`
       font-size: 1.8rem;
       font-weight: 500;
       line-height: 2.8rem;
     `,
-    '16-bold': css`
+    bold16: css`
       font-size: 1.6rem;
       font-weight: 700;
       line-height: 2.6rem;
     `,
-    '16-semibold': css`
+    semibold16: css`
       font-size: 1.6rem;
       font-weight: 600;
       line-height: 2.6rem;
     `,
-    '16-medium': css`
+    medium16: css`
       font-size: 1.6rem;
       font-weight: 500;
       line-height: 2.6rem;
     `,
-    '14-semibold': css`
+    semibold14: css`
       font-size: 1.4rem;
       font-weight: 600;
       line-height: 2.2rem;
     `,
-    '14-bold': css`
+    bold14: css`
       font-size: 1.4rem;
       font-weight: 700;
       line-height: 2.2rem;


### PR DESCRIPTION
## 🛠 관련 이슈
- #18 

## 🌱 PR 포인트
- 캘린더 페이지만 하단만 먼저 작업했숩니다.
     - 특히 `StyledContainer` 의 경우 Footer 와 상당히 css 가 유사하여 추후에 컴포넌트로도 분리할 수 있을 것 같습니다!
-  theme font 변수 네이밍 `fontweight + 크기` 요런 식으로 피그마 폰트 토큰과 맞게 수정했습니다.

## 📸 스크린샷 / 링크
|![image](https://github.com/dnd-side-project/dnd-9th-7-frontend/assets/101736358/a39e33de-b743-401f-bf3f-a0ac20d26b2f)|
|:--:|
|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->

## ❗ 이슈사항 / 기타사항 / 에러슈팅
