### PR TITLE
💄 style: 뮤직라운지 페이지 UI 제작

### DIFF
--- a/src/common/components/Router/Router.tsx
+++ b/src/common/components/Router/Router.tsx
@@ -6,6 +6,7 @@ import SituationPage from '@pages/situation';
 import OnboardingPage from '@pages/onboarding';
 import MusicSearchPage from '@pages/musicSearch';
 import PlayingSearchPage from '@pages/playingSearch';
+import MusicLoungePage from '@pages/musicLounge';
 
 export const Router = () => {
   return (
@@ -13,9 +14,10 @@ export const Router = () => {
       <Route path='/' element={<Home />} />
       <Route path='/onboarding' element={<OnboardingPage />} />
       <Route path='/record' element={<RecordPage />} />
-      <Route path='/musicSearch' element={<MusicSearchPage />} />
-      <Route path='/youtubePlay' element={<PlayingSearchPage />} />
+      <Route path='/music-search' element={<MusicSearchPage />} />
+      <Route path='/youtube-play' element={<PlayingSearchPage />} />
       <Route path='/situation' element={<SituationPage />} />
+      <Route path='/music-lounge' element={<MusicLoungePage />} />
     </Routes>
   );
 };

--- a/src/features/MusicLounge/components/Background/Background.tsx
+++ b/src/features/MusicLounge/components/Background/Background.tsx
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+import Blur from './Blur';
+
+interface Props {
+  type: string;
+  title: string;
+  color: string;
+}
+
+const Background = ({ type, title, color }: Props) => {
+  return (
+    <StyledBackground>
+      <Blur color={color} />
+
+      <StyledType>{type}</StyledType>
+      <StyledTitle>
+        {title}
+        <br />
+        많이 들은 음악
+      </StyledTitle>
+    </StyledBackground>
+  );
+};
+
+const StyledBackground = styled.div`
+  position: relative;
+  width: calc(100% + 4.8rem);
+  padding-top: 2rem;
+  padding-bottom: 2.4rem;
+  background-color: ${(props) => props.theme.color.white};
+`;
+
+const StyledType = styled.div`
+  padding-right: 2.4rem;
+  padding-left: 2.4rem;
+  text-shadow: 2px 4px 10px rgba(0, 0, 0, 0.08);
+  opacity: 0.35;
+  text-transform: uppercase;
+  ${(props) => props.theme.font.medium16}
+`;
+
+const StyledTitle = styled.div`
+  padding-right: 2.4rem;
+  padding-left: 2.4rem;
+  margin-top: 6.2rem;
+  text-shadow: 2px 4px 10px rgba(0, 0, 0, 0.08);
+  letter-spacing: -0.2px;
+  opacity: 0.99; // 왜 이게 있어야 글자가 보이는거지..?
+  ${(props) => props.theme.font.bold28}
+`;
+
+export default Background;

--- a/src/features/MusicLounge/components/Background/Background.tsx
+++ b/src/features/MusicLounge/components/Background/Background.tsx
@@ -11,7 +11,6 @@ const Background = ({ type, title, color }: Props) => {
   return (
     <StyledBackground>
       <Blur color={color} />
-
       <StyledType>{type}</StyledType>
       <StyledTitle>
         {title}

--- a/src/features/MusicLounge/components/Background/Blur.tsx
+++ b/src/features/MusicLounge/components/Background/Blur.tsx
@@ -4,16 +4,16 @@ interface Props {
   color: string;
 }
 
-export const BlurBackground = ({ color }: Props) => {
+const Blur = ({ color }: Props) => {
   return (
-    <StyledBlurBackground>
+    <StyledBlur>
       <StyledCircle color={color} />
-      <BlurFilter />
-    </StyledBlurBackground>
+      <StyledFilter />
+    </StyledBlur>
   );
 };
 
-const StyledBlurBackground = styled.div`
+const StyledBlur = styled.div`
   position: absolute;
   top: 0;
   left: 0;
@@ -32,7 +32,7 @@ const StyledCircle = styled.div<{ color: string }>`
   aspect-ratio: 1/1;
 `;
 
-const BlurFilter = styled.div`
+const StyledFilter = styled.div`
   position: absolute;
   top: 0;
   left: 0;
@@ -40,3 +40,5 @@ const BlurFilter = styled.div`
   height: 100%;
   backdrop-filter: blur(70px);
 `;
+
+export default Blur;

--- a/src/features/MusicLounge/components/Background/index.ts
+++ b/src/features/MusicLounge/components/Background/index.ts
@@ -1,0 +1,3 @@
+import Background from './Background';
+
+export default Background;

--- a/src/features/MusicLounge/components/BlurBackground.tsx
+++ b/src/features/MusicLounge/components/BlurBackground.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+interface Props {
+  color: string;
+}
+
+export const BlurBackground = ({ color }: Props) => {
+  return (
+    <StyledBlurBackground>
+      <StyledCircle color={color} />
+      <BlurFilter />
+    </StyledBlurBackground>
+  );
+};
+
+const StyledBlurBackground = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+`;
+
+const StyledCircle = styled.div<{ color: string }>`
+  position: absolute;
+  top: -5rem;
+  right: 3rem;
+  background-color: ${(props) => props.color};
+  border-radius: 100%;
+  width: 42rem;
+  aspect-ratio: 1/1;
+`;
+
+const BlurFilter = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  backdrop-filter: blur(70px);
+`;

--- a/src/features/MusicLounge/components/MusicList/Music.tsx
+++ b/src/features/MusicLounge/components/MusicList/Music.tsx
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled';
+
+interface Props {
+  music: number;
+}
+
+const Music = ({ music }: Props) => {
+  return (
+    <StyledMusic>
+      <StyledMusicNum>{music + 1}</StyledMusicNum>
+      <StyledMusicImage />
+      <div>
+        <StyledMusicTitle>WONDERWALL</StyledMusicTitle>
+        <StyledMusicArtist>OASIS</StyledMusicArtist>
+      </div>
+    </StyledMusic>
+  );
+};
+
+const StyledMusic = styled.div`
+  margin-right: 1.6rem;
+  :first-child {
+    margin-left: 2.4rem;
+  }
+  :last-child {
+    margin-right: 2.4rem;
+  }
+`;
+
+const StyledMusicNum = styled.div`
+  ${(props) => props.theme.font.medium14}
+`;
+
+const StyledMusicImage = styled.div`
+  width: 12.8rem;
+  aspect-ratio: 1/1;
+  margin: 0.8rem 0 1.2rem 0;
+  background-color: ${(props) => props.theme.color.gray11};
+`;
+
+const StyledMusicTitle = styled.div`
+  ${(props) => props.theme.font.bold16}
+`;
+
+const StyledMusicArtist = styled.div`
+  ${(props) => props.theme.font.medium14}
+  color: ${(props) => props.theme.color.gray08};
+`;
+
+export default Music;

--- a/src/features/MusicLounge/components/MusicList/MusicList.tsx
+++ b/src/features/MusicLounge/components/MusicList/MusicList.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+import Music from './Music';
+
+const MusicList = () => {
+  return (
+    <StyledMusicList>
+      {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map((music: number) => (
+        <Music key={music} music={music} />
+      ))}
+    </StyledMusicList>
+  );
+};
+
+const StyledMusicList = styled.div`
+  display: flex;
+  width: calc(100% + 4.8rem);
+  overflow-x: scroll;
+  padding: 1.6rem 0;
+`;
+
+export default MusicList;

--- a/src/features/MusicLounge/components/MusicList/index.ts
+++ b/src/features/MusicLounge/components/MusicList/index.ts
@@ -1,0 +1,3 @@
+import MusicList from './MusicList';
+
+export default MusicList;

--- a/src/features/MusicLounge/components/Navigation.tsx
+++ b/src/features/MusicLounge/components/Navigation.tsx
@@ -1,0 +1,11 @@
+import { Navigation as MusicLoungePageNavigation } from '@common/components/Navigation';
+
+export const Navigation = () => {
+  return (
+    <MusicLoungePageNavigation>
+      <MusicLoungePageNavigation.Left>
+        <span>MUSIC LOUNGE</span>
+      </MusicLoungePageNavigation.Left>
+    </MusicLoungePageNavigation>
+  );
+};

--- a/src/features/MusicLounge/components/Navigation.tsx
+++ b/src/features/MusicLounge/components/Navigation.tsx
@@ -1,6 +1,6 @@
 import { Navigation as MusicLoungePageNavigation } from '@common/components/Navigation';
 
-export const Navigation = () => {
+const Navigation = () => {
   return (
     <MusicLoungePageNavigation>
       <MusicLoungePageNavigation.Left>
@@ -9,3 +9,5 @@ export const Navigation = () => {
     </MusicLoungePageNavigation>
   );
 };
+
+export default Navigation;

--- a/src/features/MusicLounge/components/Section.tsx
+++ b/src/features/MusicLounge/components/Section.tsx
@@ -11,7 +11,6 @@ const Section = ({ type, title, color }: Props) => {
   return (
     <>
       <Background type={type} title={title} color={color} />
-
       <MusicList />
     </>
   );

--- a/src/features/MusicLounge/components/Section.tsx
+++ b/src/features/MusicLounge/components/Section.tsx
@@ -1,0 +1,20 @@
+import Background from './Background';
+import MusicList from './MusicList';
+
+interface Props {
+  type: string;
+  title: string;
+  color: string;
+}
+
+const Section = ({ type, title, color }: Props) => {
+  return (
+    <>
+      <Background type={type} title={title} color={color} />
+
+      <MusicList />
+    </>
+  );
+};
+
+export default Section;

--- a/src/features/MusicLounge/components/index.ts
+++ b/src/features/MusicLounge/components/index.ts
@@ -1,0 +1,2 @@
+export * from './Navigation';
+export * from './BlurBackground';

--- a/src/features/MusicLounge/components/index.ts
+++ b/src/features/MusicLounge/components/index.ts
@@ -1,2 +1,4 @@
-export * from './Navigation';
-export * from './BlurBackground';
+import Navigation from './Navigation';
+import Section from './Section';
+
+export { Navigation, Section };

--- a/src/pages/musicLounge/index.tsx
+++ b/src/pages/musicLounge/index.tsx
@@ -1,99 +1,16 @@
-import styled from '@emotion/styled';
-import { BlurBackground, Navigation } from '@features/MusicLounge/components';
+import { Navigation, Section } from '@features/MusicLounge/components';
 
 const MusicLoungePage = () => {
   return (
     <>
       <Navigation />
 
-      <StyledBlurBackground>
-        <BlurBackground color='#04002D' />
-
-        <StyledType>FEELING</StyledType>
-        <StyledTitle>
-          공허한 날 사람들이
-          <br />
-          많이 들은 음악
-        </StyledTitle>
-      </StyledBlurBackground>
-
-      <StyledMusicList>
-        {[0, 1, 2, 3, 4, 5, 6, 7, 8].map((music: number) => (
-          <StyledMusic key={music}>
-            <StyledMusicNum>{music + 1}</StyledMusicNum>
-            <StyledMusicImage />
-            <div>
-              <StyledMusicTitle>WONDERWALL</StyledMusicTitle>
-              <StyledMusicArtist>OASIS</StyledMusicArtist>
-            </div>
-          </StyledMusic>
-        ))}
-      </StyledMusicList>
+      <Section type='FEELING' title='공허한 날 사람들이' color='#04002D' />
+      <Section type='TIME' title='새벽에 사람들이' color='#3D33AA' />
+      <Section type='WEATHER' title='비오는 날 사람들이' color='#128A92' />
+      <Section type='SEASON' title='여름에 사람들이' color='#4290EC' />
     </>
   );
 };
-
-const StyledBlurBackground = styled.div`
-  position: relative;
-  width: calc(100% + 4.8rem);
-  padding-top: 2rem;
-  padding-bottom: 2.4rem;
-  background-color: ${(props) => props.theme.color.white};
-`;
-
-const StyledType = styled.div`
-  padding-right: 2.4rem;
-  padding-left: 2.4rem;
-  text-shadow: 2px 4px 10px rgba(0, 0, 0, 0.08);
-  opacity: 0.35;
-  ${(props) => props.theme.font.medium16}
-`;
-
-const StyledTitle = styled.div`
-  padding-right: 2.4rem;
-  padding-left: 2.4rem;
-  margin-top: 6.2rem;
-  text-shadow: 2px 4px 10px rgba(0, 0, 0, 0.08);
-  letter-spacing: -0.2px;
-  opacity: 0.99; // 왜 이게 있어야 글자가 보이는거지..?
-  ${(props) => props.theme.font.bold28}
-`;
-
-const StyledMusicList = styled.div`
-  display: flex;
-  width: calc(100% + 4.8rem);
-  overflow-x: scroll;
-  padding: 1.6rem 0;
-`;
-
-const StyledMusic = styled.div`
-  margin-right: 1.6rem;
-  :first-child {
-    margin-left: 2.4rem;
-  }
-  :last-child {
-    margin-right: 2.4rem;
-  }
-`;
-
-const StyledMusicNum = styled.div`
-  ${(props) => props.theme.font.medium14}
-`;
-
-const StyledMusicImage = styled.div`
-  width: 12.8rem;
-  aspect-ratio: 1/1;
-  margin: 0.8rem 0 1.2rem 0;
-  background-color: ${(props) => props.theme.color.gray11};
-`;
-
-const StyledMusicTitle = styled.div`
-  ${(props) => props.theme.font.bold16}
-`;
-
-const StyledMusicArtist = styled.div`
-  ${(props) => props.theme.font.medium14}
-  color: ${(props) => props.theme.color.gray08};
-`;
 
 export default MusicLoungePage;

--- a/src/pages/musicLounge/index.tsx
+++ b/src/pages/musicLounge/index.tsx
@@ -4,7 +4,6 @@ const MusicLoungePage = () => {
   return (
     <>
       <Navigation />
-
       <Section type='FEELING' title='공허한 날 사람들이' color='#04002D' />
       <Section type='TIME' title='새벽에 사람들이' color='#3D33AA' />
       <Section type='WEATHER' title='비오는 날 사람들이' color='#128A92' />

--- a/src/pages/musicLounge/index.tsx
+++ b/src/pages/musicLounge/index.tsx
@@ -1,0 +1,99 @@
+import styled from '@emotion/styled';
+import { BlurBackground, Navigation } from '@features/MusicLounge/components';
+
+const MusicLoungePage = () => {
+  return (
+    <>
+      <Navigation />
+
+      <StyledBlurBackground>
+        <BlurBackground color='#04002D' />
+
+        <StyledType>FEELING</StyledType>
+        <StyledTitle>
+          공허한 날 사람들이
+          <br />
+          많이 들은 음악
+        </StyledTitle>
+      </StyledBlurBackground>
+
+      <StyledMusicList>
+        {[0, 1, 2, 3, 4, 5, 6, 7, 8].map((music: number) => (
+          <StyledMusic key={music}>
+            <StyledMusicNum>{music + 1}</StyledMusicNum>
+            <StyledMusicImage />
+            <div>
+              <StyledMusicTitle>WONDERWALL</StyledMusicTitle>
+              <StyledMusicArtist>OASIS</StyledMusicArtist>
+            </div>
+          </StyledMusic>
+        ))}
+      </StyledMusicList>
+    </>
+  );
+};
+
+const StyledBlurBackground = styled.div`
+  position: relative;
+  width: calc(100% + 4.8rem);
+  padding-top: 2rem;
+  padding-bottom: 2.4rem;
+  background-color: ${(props) => props.theme.color.white};
+`;
+
+const StyledType = styled.div`
+  padding-right: 2.4rem;
+  padding-left: 2.4rem;
+  text-shadow: 2px 4px 10px rgba(0, 0, 0, 0.08);
+  opacity: 0.35;
+  ${(props) => props.theme.font.medium16}
+`;
+
+const StyledTitle = styled.div`
+  padding-right: 2.4rem;
+  padding-left: 2.4rem;
+  margin-top: 6.2rem;
+  text-shadow: 2px 4px 10px rgba(0, 0, 0, 0.08);
+  letter-spacing: -0.2px;
+  opacity: 0.99; // 왜 이게 있어야 글자가 보이는거지..?
+  ${(props) => props.theme.font.bold28}
+`;
+
+const StyledMusicList = styled.div`
+  display: flex;
+  width: calc(100% + 4.8rem);
+  overflow-x: scroll;
+  padding: 1.6rem 0;
+`;
+
+const StyledMusic = styled.div`
+  margin-right: 1.6rem;
+  :first-child {
+    margin-left: 2.4rem;
+  }
+  :last-child {
+    margin-right: 2.4rem;
+  }
+`;
+
+const StyledMusicNum = styled.div`
+  ${(props) => props.theme.font.medium14}
+`;
+
+const StyledMusicImage = styled.div`
+  width: 12.8rem;
+  aspect-ratio: 1/1;
+  margin: 0.8rem 0 1.2rem 0;
+  background-color: ${(props) => props.theme.color.gray11};
+`;
+
+const StyledMusicTitle = styled.div`
+  ${(props) => props.theme.font.bold16}
+`;
+
+const StyledMusicArtist = styled.div`
+  ${(props) => props.theme.font.medium14}
+  color: ${(props) => props.theme.color.gray08};
+`;
+
+export default MusicLoungePage;


### PR DESCRIPTION
## 🛠 관련 이슈
- Resolved: #40 

## 🌱 PR 포인트
- 뮤직라운지 페이지 UI 제작 완료하였습니다.
- 피그마 디자인 시스템에 블러처리 되는 배경색 전부 나와있는데, 우선 theme에 저장해서 사용할까요?
나중에는 백에서 받아오는 색상값들이긴 합니다.
- 페이지 기능 개발하며 msw 활용해 api 연동 작업하겠습니다.
- 추가로 Router의 path url의 대문자는 하이픈(-)으로 변경했습니다.

## 📸 스크린샷 / 링크
|스크린샷|
|:--:|
| <img src="https://github.com/dnd-side-project/dnd-9th-7-frontend/assets/61397627/7b8ba250-9ecf-4b45-85f7-8b3c34625ef4" width="400" />|

## ❗ 이슈사항 / 기타사항 / 에러슈팅
- 디렉토리 구조가 아직 익숙치 않아서 컴포넌트 쪼개는데 이상한 점 있는지 확인 부탁드려용
-  페이지 스크롤 시 `Navigation` 컴포넌트 css에 약간의 깨짐 현상이 있습니다.
- 작업하다보니 겹치는 css들이 은근 많더라구요(노래 제목, 가수명 등등..) 이 점도 인지해놓고 있겠습니다.
