### PR TITLE
💄 style: 스크롤 시 Navigation, Footer 컴포넌트 깨짐 현상 수정

### DIFF
--- a/src/common/components/Footer/Footer.tsx
+++ b/src/common/components/Footer/Footer.tsx
@@ -9,6 +9,7 @@ export const Footer = ({ children }: PropsWithChildren) => {
 const FooterLeft = ({ children }: PropsWithChildren) => (
   <StyledFooterLeft>{children}</StyledFooterLeft>
 );
+
 const FooterRight = ({ children }: PropsWithChildren) => (
   <StyledFooterRight>{children}</StyledFooterRight>
 );
@@ -18,11 +19,12 @@ const FooterCenter = ({ children }: PropsWithChildren) => (
 );
 
 const StyledFooter = styled.footer`
-  position: sticky;
+  position: fixed;
   height: 5.8rem;
-  width: calc(100% + 4.8rem);
+  width: 100%;
+  max-width: calc(34.2rem + 4.8rem);
   bottom: 0;
-  z-index: 10;
+  z-index: 99;
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   background-color: ${theme.color.gray12};
@@ -45,6 +47,7 @@ const StyledFooterCenter = styled.div`
   grid-auto-flow: column;
   place-items: center;
 `;
+
 Footer.Left = FooterLeft;
 Footer.Right = FooterRight;
 Footer.Center = FooterCenter;

--- a/src/common/components/Navigation/Navigation.tsx
+++ b/src/common/components/Navigation/Navigation.tsx
@@ -9,6 +9,7 @@ export const Navigation = ({ children }: PropsWithChildren) => {
 const NavigationLeft = ({ children }: PropsWithChildren) => (
   <StyledNavigationLeft>{children}</StyledNavigationLeft>
 );
+
 const NavigationRight = ({ children }: PropsWithChildren) => (
   <StyledNavigationRight>{children}</StyledNavigationRight>
 );
@@ -20,14 +21,14 @@ const NavigationCenter = ({ children }: PropsWithChildren) => (
 const StyledNavigation = styled.header`
   position: sticky;
   top: 0;
-  z-index: 10;
   display: flex;
-  height: 6.8rem;
-  width: 100%;
-  flex-shrink: 0;
-  align-items: center;
   justify-content: space-between;
+  align-items: center;
+  width: calc(100% + 4.8rem);
+  height: 6.8rem;
   background-color: ${theme.color.black};
+  flex-shrink: 0;
+  z-index: 99;
   ${theme.font.bold22};
 `;
 
@@ -35,12 +36,14 @@ const StyledNavigationLeft = styled.div`
   display: grid;
   grid-auto-flow: column;
   place-items: center;
+  padding-left: 2.4rem;
 `;
 
 const StyledNavigationRight = styled.div`
   display: grid;
   grid-auto-flow: column;
   place-items: center;
+  padding-right: 2.4rem;
   ${theme.font.semibold16}
 `;
 
@@ -50,6 +53,7 @@ const StyledNavigationCenter = styled.span`
   transform: translateX(-50%);
   ${theme.font.semibold18}
 `;
+
 Navigation.Left = NavigationLeft;
 Navigation.Right = NavigationRight;
 Navigation.Center = NavigationCenter;


### PR DESCRIPTION
## 🛠 관련 이슈
- Resolved: #45 

## 🌱 PR 포인트
- 스크롤 시 `Navigation`, `Footer` 컴포넌트가 깨지는 현상 수정했습니다.
- `Navigation` 컴포넌트는 `position: sticky`, `Footer` 컴포넌트는 `position: fixed`로 설정했습니다.

## ❗ 이슈사항 / 기타사항 / 에러슈팅
