### PR TITLE
fix : emotion css prop 쓸 수 있도록 수정

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,60 +1,55 @@
 {
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "project": "./tsconfig.json"
-    },  
-    "ignorePatterns": ["./vite.config.ts"],
-    "env": {
-        "browser": true,
-        "es6": true,
-        "node": true
-    },
-    "extends": [
-        "airbnb",
-        "airbnb/hooks",
-        "airbnb-typescript",
-        "plugin:prettier/recommended",
-        "plugin:@typescript-eslint/recommended"
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "ignorePatterns": ["./vite.config.ts"],
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "extends": [
+    "airbnb",
+    "airbnb/hooks",
+    "airbnb-typescript",
+    "plugin:prettier/recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
+    "react/function-component-definition": [2, { "namedComponents": "arrow-function" }],
+    "react/prop-types": 0,
+    "import/no-unresolved": "off",
+    "import/no-cycle": "off",
+    "no-param-reassign": "off",
+    "no-use-before-define": "off",
+    "@typescript-eslint/no-use-before-define": "off",
+    "react/react-in-jsx-scope": "off",
+    "react/no-unknown-property": ["error", { "ignore": ["css"] }],
+    "import/prefer-default-export": "off",
+    "react/jsx-props-no-spreading": "off",
+    "global-require": "warn",
+    "prettier/prettier": [
+      "error",
+      {
+        "singleQuote": true,
+        "endOfLine": "auto"
+      }
     ],
-    "plugins": ["@typescript-eslint"],
-    "rules": {
-        "react/jsx-filename-extension": [
-            1,
-            { "extensions": [".js", ".jsx", ".ts", ".tsx"] }
-        ],
-        "react/function-component-definition": [
-            2,
-            { "namedComponents": "arrow-function" }
-        ],
-        "react/prop-types": 0,
-        "import/no-unresolved": "off",
-        "import/no-cycle": "off",
-        "no-param-reassign": "off",
-        "no-use-before-define": "off",
-        "@typescript-eslint/no-use-before-define": "off",    
-        "react/react-in-jsx-scope" : "off",
-        "import/prefer-default-export" : "off", 
-        "react/jsx-props-no-spreading" : "off", 
-        "global-require": "warn", 
-        "prettier/prettier": [
-            "error",
-            {
-                "singleQuote": true,
-                "endOfLine": "auto"
-            }
-        ],
-        "import/no-extraneous-dependencies" : "off",
-        "react/require-default-props" : "off",
-        "react/button-has-type" : "off",
-        "import/extensions": [
-            "off",
-            "ignorePackages",
-            {
-              "js": "never",
-              "jsx": "never",
-              "ts": "never",
-              "tsx": "never"
-            }
-         ]
-    }    
+    "import/no-extraneous-dependencies": "off",
+    "react/require-default-props": "off",
+    "react/button-has-type": "off",
+    "import/extensions": [
+      "off",
+      "ignorePackages",
+      {
+        "js": "never",
+        "jsx": "never",
+        "ts": "never",
+        "tsx": "never"
+      }
+    ]
+  }
 }

--- a/src/features/MusicSearch/components/MusicSearchInput.tsx
+++ b/src/features/MusicSearch/components/MusicSearchInput.tsx
@@ -1,4 +1,3 @@
-/** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { SetStateAction, KeyboardEvent, Dispatch } from 'react';

--- a/src/features/Record/components/Date/RecordDate.tsx
+++ b/src/features/Record/components/Date/RecordDate.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-unknown-property */
-/** @jsxImportSource @emotion/react */
 import { useState } from 'react';
 import { DateValue } from 'src/types';
 import { css } from '@emotion/react';

--- a/src/features/common/components/SearchInput.tsx
+++ b/src/features/common/components/SearchInput.tsx
@@ -1,4 +1,3 @@
-/** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { SetStateAction, KeyboardEvent, Dispatch } from 'react';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-unknown-property */
-/** @jsxImportSource @emotion/react */
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { css } from '@emotion/react';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,12 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "baseUrl": ".",
-		"paths": {
-			"@/*": ["./src/*"],
+    "paths": {
+      "@/*": ["./src/*"],
       "@/public/*": ["./public/*"]
-		},
+    },
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -24,10 +20,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["@emotion/react/types/css-prop","vite/client", "vite-plugin-svgr/client"]
+    "jsxImportSource": "@emotion/react",
+    "types": ["@emotion/react/types/css-prop", "vite/client", "vite-plugin-svgr/client"]
   },
-  "include": [
-    "public",
-    "src",
-  ],
+  "include": ["public", "src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,23 @@
-import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
-import svgrPlugin from "vite-plugin-svgr";
-import * as path from "path";
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+import svgrPlugin from 'vite-plugin-svgr';
+import * as path from 'path';
 
 export default defineConfig({
-	plugins: [react(), svgrPlugin()],
-	server: {
-		port: 3000,
-	},
-	resolve: {
-        alias: {
-			"@": path.resolve(__dirname, "./src"),
-            "@/public": path.resolve(__dirname, "./public")
-		},
-	},
+  plugins: [
+    react({
+      jsxImportSource: '@emotion/react',
+    }),
+    ,
+    svgrPlugin(),
+  ],
+  server: {
+    port: 3000,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      '@/public': path.resolve(__dirname, './public'),
+    },
+  },
 });


### PR DESCRIPTION
## 🛠 관련 이슈
- Resolved: #23

## 🌱 PR 포인트
- emotion css prop 이 먹지 않는 버그를 해결하기 위해 tsconfig와 vite.config 파일에 `"jsxImportSource": "@emotion/react"` 설저을 추가합니다.
- lint 설정에서 `"react/no-unknown-property": ["error", { "ignore": ["css"] }]`, 을 추가하여 css prop 이 unknown 으로 인식되지 않도록 합니다.

## 📸 스크린샷 / 링크
|스크린샷|
|:--:|
|파일첨부바람|

## 📎 레퍼런스
- https://chinsun9.github.io/2022/03/21/emotion-css-prop-with-vite-react/

## ❗ 이슈사항 / 기타사항 / 에러슈팅
